### PR TITLE
Relax setuptools requirement

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -237,7 +237,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "c383788bf99cf49e19d92e010a09c8b35398fc5afbd4980f55e4514696eee344"
+content-hash = "74345be77f4f29ecf7897093ad64c01246cbc00fd4192aa2d914d579992c3bf7"
 python-versions = "^3.7"
 
 [metadata.hashes]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.7"
 numpy = "^1.17"
-setuptools = "=40.8.0"
+setuptools = ">=40"
 
 [tool.poetry.dev-dependencies]
 Jinja2 = "^2.10"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ package_data = \
 {'': ['*']}
 
 install_requires = \
-['numpy>=1.17,<2.0', 'setuptools==40.8.0']
+['numpy>=1.17,<2.0', 'setuptools>=40']
 
 setup_kwargs = {
     'name': 'blueye.protocol',


### PR DESCRIPTION
I ran into a poetry bug when trying to build the sdk with poetry in a docker container, where there's a conflict between the setuptools version causing poetry to crash. The issue is logged [here](https://github.com/sdispater/poetry/issues/1226), but there doesn't seem to be a fix in the works just yet, so for now a simple workaround is to relax the version requirement for setuptools to >=40.