### PR TITLE
Truncate corrupted log files

### DIFF
--- a/blueye/protocol/udp_protocol_parser.py
+++ b/blueye/protocol/udp_protocol_parser.py
@@ -64,7 +64,11 @@ class AppProtocol:
                 return None
             dtype = list(zip(self.get_field_names(packet_type, version=version),
                              self.get_numpy_field_dtypes(packet_type, version=version)))
-            return np.frombuffer(bin_file.read(), dtype=dtype)
+            data = bin_file.read()
+            # Truncate if there is corrupt data
+            row_len = struct.calcsize(self.get_struct_format(packet_type, version=version))
+            data = data[:(int(len(data)/row_len)*row_len)]
+            return np.frombuffer(data, dtype=dtype)
 
     def pack_data(self, data):
         version = data[0]

--- a/blueye/protocol/udp_protocol_parser.py
+++ b/blueye/protocol/udp_protocol_parser.py
@@ -67,9 +67,9 @@ class AppProtocol:
             data = bin_file.read()
             row_len = struct.calcsize(self.get_struct_format(packet_type, version=version))
             # Calculate how many full rows are in the file
-            n_rows = int(len(data)/row_len)
+            n_rows = int(len(data) / row_len)
             # Truncate after last full row if there is corrupt data
-            data = data[:(n_rows*row_len)]
+            data = data[:(n_rows * row_len)]
             return np.frombuffer(data, dtype=dtype)
 
     def pack_data(self, data):

--- a/blueye/protocol/udp_protocol_parser.py
+++ b/blueye/protocol/udp_protocol_parser.py
@@ -65,9 +65,11 @@ class AppProtocol:
             dtype = list(zip(self.get_field_names(packet_type, version=version),
                              self.get_numpy_field_dtypes(packet_type, version=version)))
             data = bin_file.read()
-            # Truncate if there is corrupt data
             row_len = struct.calcsize(self.get_struct_format(packet_type, version=version))
-            data = data[:(int(len(data)/row_len)*row_len)]
+            # Calculate how many full rows are in the file
+            n_rows = int(len(data)/row_len)
+            # Truncate after last full row if there is corrupt data
+            data = data[:(n_rows*row_len)]
             return np.frombuffer(data, dtype=dtype)
 
     def pack_data(self, data):


### PR DESCRIPTION
when using np.fromfile this wasn't necessary, but np.frombuffer
fails when getting a file which has a size that is not the multiple
of the size of a binary log entry.